### PR TITLE
feat: updated stimulus sequence to RSVP experiment

### DIFF
--- a/autora_closed_loop_demo/researcher_hub/stimulus_sequence.py
+++ b/autora_closed_loop_demo/researcher_hub/stimulus_sequence.py
@@ -1,7 +1,78 @@
-from sweetbean.stimulus import FixationStimulus, BlankStimulus, RandomDotPatternsStimulus
+import sweetbean
+
 from sweetbean.parameter import TimelineVariable
 from sweetbean.sequence import Block, Experiment
+from sweetbean.stimulus import TextStimulus, BlankStimulus, FeedbackStimulus, RandomDotPatternsStimulus
 
+
+def stimulus_sequence(timeline, coherence_ratio, coherence_direction):
+    # introduction TODO write introduction
+    introduction = TextStimulus(text='Welcome to this experiment!<br>...<br>Press SPACE to continue.', choices=[" "])
+
+    # instruction TODO write instruction
+    instruction = TextStimulus(text='... Press SPACE to continue.', choices=[" "])
+
+    # break TODO incorporate breaks after specific number of trials
+    pause = TextStimulus(text='Feel free to take a short break now<br>Press SPACE when you are ready to continue the experiment.', choices=[" "])
+
+    # debriefing/closure TODO write debriefing
+    debriefing = TextStimulus(text='... Thank you for your participation!<br>Press SPACE to end the experiment.', choices=[" "])
+
+
+
+    # fixation cross and blank screens around it
+    fixation_onset = BlankStimulus(duration=680)
+    fixation = TextStimulus(duration=915, text="+")
+    fixation_offset = BlankStimulus(duration=400)
+
+    # blank screen in between items within a trial
+    between_items = BlankStimulus(duration=45)
+
+    # participant response
+    response = TextStimulus(text="Which two numbers did you see during the previously displayed sequence?", choices=[1, 2, 3, 4])
+
+    # timeline variables
+    # independent variables
+    coherence_ratio = TimelineVariable("coherence_ratio", [])
+    coherence_direction = TimelineVariable("coherence_direction", [])
+
+    rdp = RandomDotPatternsStimulus(
+        duration=75,
+        number_of_oobs=20,
+        number_of_apertures=1,
+        #coherence_movement=coherence_ratio,
+        #movement_speed=14.2
+        oob_color="white",
+        background_color="black"
+    )
+
+    # create all lists of sequences and individual blocks
+    introduction_list = [introduction]
+    introduction_block = Block(introduction_list)
+
+    instruction_list = [instruction]
+    instruction_block = Block(instruction_list)
+
+    training_list = [fixation_onset, fixation, rdp, fixation_offset]
+    training_block = Block(training_list)
+    experiment_list = [fixation_onset, fixation, rdp, fixation_offset]
+    experiment_block = Block(experiment_list, timeline)
+
+    response_list = [response, response]
+    respone_block = Block(response_list)
+
+    debriefing_list = [debriefing]
+    debriefing_block = Block(debriefing_list)
+
+    # setting up the final experiment consisting of all blocks
+    block_list = [introduction_block, instruction_block, training_block, experiment_block, debriefing_block]
+    experiment = Experiment(block_list)
+
+    # return a js string to transfer experiment to autora
+    #return experiment.to_js_string(as_function=True, is_async=True)
+
+
+'''
 def stimulus_sequence(timeline, intensity_1, intensity_2):
     fixation = FixationStimulus(800)
     blank_1 = BlankStimulus(400)
@@ -23,3 +94,4 @@ def stimulus_sequence(timeline, intensity_1, intensity_2):
     experiment = Experiment([block])
     # return a js string to transfer to autora
     return experiment.to_js_string(as_function=True, is_async=True)
+'''


### PR DESCRIPTION
# Description

added first draft for stimulus sequence based on the RSVP task of interest, i.e. Tsushima et al. (2006)

*If the issue is on Github, simply link to it using the '#' symbol; otherwise, provide a notion page link)*:
- resolves #5 

# Type of change

*Delete as appropriate:*
- **feat**: A new feature

# Features (Optional)
- added first draft of introduction, instruction, training, experiment, break, and debriefing block